### PR TITLE
Add formatters for to_addr when needed

### DIFF
--- a/message_sender/formatters.py
+++ b/message_sender/formatters.py
@@ -1,0 +1,15 @@
+import re
+
+
+def noop(msisdn):
+    return msisdn
+
+
+def vas2nets_voice(msisdn):
+    """
+    FIXME: this should not need be in this repo
+
+    Vas2Nets is an aggregator in Nigeria, for some reason they need
+    MSISDNs prefixed with a 9 instead of the country code to initiate an OBD.
+    """
+    return re.sub(r'\+?234(\d+)$', r'9\1', msisdn)

--- a/message_sender/tasks.py
+++ b/message_sender/tasks.py
@@ -14,8 +14,12 @@ from requests.exceptions import HTTPError
 
 
 from .models import Outbound
+from seed_message_sender.utils import load_callable
 
 logger = get_task_logger(__name__)
+
+voice_to_addr_formatter = load_callable(settings.VOICE_TO_ADDR_FORMATTER)
+text_to_addr_formatter = load_callable(settings.TEXT_TO_ADDR_FORMATTER)
 
 
 class DeliverHook(Task):
@@ -120,7 +124,8 @@ class Send_Message(Task):
                         sender = self.vumi_client_voice()
                         speech_url = message.metadata["voice_speech_url"]
                         vumiresponse = sender.send_voice(
-                            message.to_addr, message.content,
+                            voice_to_addr_formatter(message.to_addr),
+                            message.content,
                             speech_url=speech_url,
                             session_event="new")
                         l.info("Sent voice message to <%s>" % message.to_addr)
@@ -128,7 +133,8 @@ class Send_Message(Task):
                         # Plain content
                         sender = self.vumi_client_text()
                         vumiresponse = sender.send_text(
-                            message.to_addr, message.content,
+                            text_to_addr_formatter(message.to_addr),
+                            message.content,
                             session_event="new")
                         l.info("Sent text message to <%s>" % message.to_addr)
                     message.attempts += 1

--- a/seed_message_sender/settings.py
+++ b/seed_message_sender/settings.py
@@ -203,8 +203,10 @@ VUMI_CONVERSATION_KEY_VOICE = \
 VUMI_ACCOUNT_TOKEN_VOICE = \
     os.environ.get('MESSAGE_SENDER_VUMI_ACCOUNT_TOKEN_VOICE', 'conv-token')
 
-VOICE_TO_ADDR_FORMATTER = 'message_sender.formatters.noop'
-TEXT_TO_ADDR_FORMATTER = 'message_sender.formatters.noop'
+VOICE_TO_ADDR_FORMATTER = os.environ.get(
+    'VOICE_TO_ADDR_FORMATTER', 'message_sender.formatters.noop')
+TEXT_TO_ADDR_FORMATTER = os.environ.get(
+    'TEXT_TO_ADDR_FORMATTER', 'message_sender.formatters.noop')
 
 VUMI_API_URL_TEXT = \
     os.environ.get('MESSAGE_SENDER_VUMI_API_URL_TEXT',

--- a/seed_message_sender/settings.py
+++ b/seed_message_sender/settings.py
@@ -203,6 +203,9 @@ VUMI_CONVERSATION_KEY_VOICE = \
 VUMI_ACCOUNT_TOKEN_VOICE = \
     os.environ.get('MESSAGE_SENDER_VUMI_ACCOUNT_TOKEN_VOICE', 'conv-token')
 
+VOICE_TO_ADDR_FORMATTER = 'message_sender.formatters.noop'
+TEXT_TO_ADDR_FORMATTER = 'message_sender.formatters.noop'
+
 VUMI_API_URL_TEXT = \
     os.environ.get('MESSAGE_SENDER_VUMI_API_URL_TEXT',
                    'http://example.com/api/v1/go/http_api_nostream')

--- a/seed_message_sender/utils.py
+++ b/seed_message_sender/utils.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from importlib import import_module
 
 
 def get_available_metrics():
@@ -7,3 +8,10 @@ def get_available_metrics():
     available_metrics.extend(settings.METRICS_SCHEDULED)
 
     return available_metrics
+
+
+def load_callable(dotted_path_to_callable):
+    module_name, func_name = dotted_path_to_callable.rsplit('.', 1)
+    mod = import_module(module_name)
+    func = getattr(mod, func_name)
+    return func


### PR DESCRIPTION
Some aggregators require special formatting for a number before sending it out.
