### PR TITLE
Add number formatter for vas2nets

### DIFF
--- a/message_sender/formatters.py
+++ b/message_sender/formatters.py
@@ -13,3 +13,14 @@ def vas2nets_voice(msisdn):
     MSISDNs prefixed with a 9 instead of the country code to initiate an OBD.
     """
     return re.sub(r'\+?234(\d+)$', r'90\1', msisdn)
+
+
+def vas2nets_text(msisdn):
+    """
+    FIXME: this should not need be in this repo
+
+    Vas2Nets is an aggregator in Nigeria, they need MSISDNs in the local
+    format, prefixed with a 0, instead of the international format with the
+    country code.
+    """
+    return re.sub(r'\+?234(\d+)$', r'0\1', msisdn)

--- a/message_sender/tests.py
+++ b/message_sender/tests.py
@@ -748,10 +748,17 @@ class TestFormatter(TestCase):
 
     @override_settings(
         VOICE_TO_ADDR_FORMATTER='message_sender.formatters.vas2nets_voice')
-    def test_vas2nets(self):
+    def test_vas2nets_voice(self):
         cb = load_callable(settings.VOICE_TO_ADDR_FORMATTER)
         self.assertEqual(cb('+23456'), '9056')
         self.assertEqual(cb('23456'), '9056')
+
+    @override_settings(
+        VOICE_TO_ADDR_FORMATTER='message_sender.formatters.vas2nets_text')
+    def test_vas2nets_text(self):
+        cb = load_callable(settings.VOICE_TO_ADDR_FORMATTER)
+        self.assertEqual(cb('+23456'), '056')
+        self.assertEqual(cb('23456'), '056')
 
 
 class TestFactory(TestCase):


### PR DESCRIPTION
For vas2nets text outbound, the destination number should be in the `0803..` format instead of the `+234803` country code format. We should add a formatter to properly format the address before it gets sent out.
