### PR TITLE
Add event support to junebug message sender integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 python:
   - "2.7"
   - "3.4"
@@ -7,8 +8,8 @@ addons:
 services:
   - postgresql
 install:
-  - "pip install -e . --use-mirrors"
-  - "pip install -r requirements-dev.txt --use-wheel"
+  - "pip install -e ."
+  - "pip install -r requirements-dev.txt"
 script:
-  - flake8 .
-  - py.test --ds=seed_message_sender.testsettings */tests.py
+  - flake8
+  - py.test

--- a/message_sender/factory.py
+++ b/message_sender/factory.py
@@ -1,10 +1,13 @@
 import json
 
 from django.conf import settings
+from django.core.urlresolvers import reverse
 
 import requests
 
 from go_http.send import HttpApiSender
+
+from .utils import make_absolute_url
 
 
 class FactoryException(Exception):
@@ -53,6 +56,7 @@ class JunebugApiSender(HttpApiSender):
             'from': self.from_addr,
             'content': py_data['content'],
             'channel_data': channel_data,
+            'event_url': make_absolute_url(reverse('junebug-events')),
         }
 
         data = json.dumps(data)

--- a/message_sender/test_utils.py
+++ b/message_sender/test_utils.py
@@ -1,0 +1,29 @@
+from django.test import TestCase, override_settings
+
+from .utils import make_absolute_url
+
+
+class TestMakeAbsoluteUrl(TestCase):
+    @override_settings(USE_SSL=True)
+    def test_make_absolute_url_ssl_true(self):
+        """
+        If USE_SSL is True, then then the url should be using https
+        """
+        self.assertEqual(
+            make_absolute_url('foo'),
+            'https://example.com/foo')
+        self.assertEqual(
+            make_absolute_url('/foo'),
+            'https://example.com/foo')
+
+    @override_settings(USE_SSL=False)
+    def test_make_absolute_url_ssl_false(self):
+        """
+        If USE_SSL is False, then then the url should be using http
+        """
+        self.assertEqual(
+            make_absolute_url('foo'),
+            'http://example.com/foo')
+        self.assertEqual(
+            make_absolute_url('/foo'),
+            'http://example.com/foo')

--- a/message_sender/tests.py
+++ b/message_sender/tests.py
@@ -854,6 +854,8 @@ class TestJunebugAPISender(TestCase):
         self.assertEqual(r['from'], '+4321')
         self.assertEqual(r['content'], 'Test')
         self.assertEqual(r['channel_data']['session_event'], 'resume')
+        self.assertEqual(
+            r['event_url'], 'http://example.com/api/v1/events/junebug')
 
     @override_settings(MESSAGE_BACKEND_VOICE='junebug',
                        JUNEBUG_API_URL_VOICE='http://example.com/',
@@ -885,6 +887,8 @@ class TestJunebugAPISender(TestCase):
         self.assertEqual(
             r['channel_data']['voice']['speech_url'], 'http://test.mp3')
         self.assertEqual(r['channel_data']['voice']['wait_for'], '#')
+        self.assertEqual(
+            r['event_url'], 'http://example.com/api/v1/events/junebug')
 
     @override_settings(MESSAGE_BACKEND_VOICE='junebug')
     def test_fire_metric(self):

--- a/message_sender/utils.py
+++ b/message_sender/utils.py
@@ -1,0 +1,17 @@
+from django.conf import settings
+from django.contrib.sites.shortcuts import get_current_site
+
+try:
+    from urlparse import urlunparse
+except ImportError:
+    from urllib.parse import urlunparse
+
+
+def make_absolute_url(path):
+    # NOTE: We're using the default site as set by
+    #       settings.SITE_ID and the Sites framework
+    site = get_current_site(None)
+    return urlunparse(
+        ('https' if settings.USE_SSL else 'http',
+         site.domain, path,
+         '', '', ''))

--- a/seed_message_sender/settings.py
+++ b/seed_message_sender/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.sites',
     # documentation
     'rest_framework_docs',
     # 3rd party
@@ -56,6 +57,9 @@ INSTALLED_APPS = (
     'message_sender',
 
 )
+
+SITE_ID = 1
+USE_SSL = os.environ.get('USE_SSL', 'false').lower() == 'true'
 
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 
-exclude = */migrations/*.py,*/manage.py
+exclude = */migrations/*.py,*/manage.py,ve/*
 
 [pytest]
 python_files=test*.py
-addopts = --verbose --ds=seed_message_sender.testsettings
+addopts = --verbose --ds=seed_message_sender.testsettings --ignore=ve


### PR DESCRIPTION
While we have the endpoint for Junebug events to be received, we're not sending that URL along with each message so that the events get back to us.

The plan is to add the sites framework, and use the sites framework to create an absolute URL, and send the absolute events url along with each message to Junebug.