### PR TITLE
Hide concurrency limiter code in views behind a feature flag

### DIFF
--- a/message_sender/tests.py
+++ b/message_sender/tests.py
@@ -404,6 +404,7 @@ class TestVumiMessagesAPI(AuthenticatedAPITestCase):
         d = Inbound.objects.filter(id=existing).count()
         self.assertEqual(d, 0)
 
+    @override_settings(CONCURRENT_VOICE_LIMIT=1)
     def test_create_inbound_event_message(self):
         existing_outbound = self.make_outbound()
         out = Outbound.objects.get(pk=existing_outbound)
@@ -728,12 +729,9 @@ class TestJunebugMessagesAPI(AuthenticatedAPITestCase):
             "channel_id": "test_voice",
             "channel_data": {"session_event": "close"}
         }
-        with patch.object(ConcurrencyLimiter, 'decr_message_count') as \
-                mock_method:
-            response = self.client.post('/api/v1/inbound/',
-                                        json.dumps(post_inbound),
-                                        content_type='application/json')
-            mock_method.assert_called_once_with("text", out.created_at)
+        response = self.client.post('/api/v1/inbound/',
+                                    json.dumps(post_inbound),
+                                    content_type='application/json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         d = Inbound.objects.last()

--- a/message_sender/views.py
+++ b/message_sender/views.py
@@ -1,5 +1,4 @@
-import sys
-import json
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.auth.models import User
 from rest_hooks.models import Hook
@@ -99,7 +98,9 @@ class InboundViewSet(viewsets.ModelViewSet):
         return InboundSerializer
 
     def create(self, request, *args, **kwargs):
-        sys.stderr.write(json.dumps(request.data))
+        if int(getattr(settings, 'CONCURRENT_VOICE_LIMIT', 0)) == 0:
+            return super(InboundViewSet, self).create(request, *args, **kwargs)
+
         close_event = False
         if "channel_data" in request.data:  # Handle message from Junebug
             if "session_event" in request.data["channel_data"]:

--- a/message_sender/views.py
+++ b/message_sender/views.py
@@ -103,11 +103,11 @@ class InboundViewSet(viewsets.ModelViewSet):
 
         close_event = False
         if "channel_data" in request.data:  # Handle message from Junebug
-            if "session_event" in request.data["channel_data"]:
-                if request.data["channel_data"]["session_event"] == "close":
-                    close_event = True
-                    reply_field = "reply_to"
-                    from_field = "from"
+            if request.data["channel_data"].get("session_event", None) == \
+                    "close":
+                close_event = True
+                reply_field = "reply_to"
+                from_field = "from"
         elif "session_event" in request.data:  # Handle message from Vumi
             if request.data["session_event"] == "close":
                 close_event = True


### PR DESCRIPTION
The code required by the concurrency limiter to determine the message type of inbound messages should only be run if the concurrency limiter is in use.