### PR TITLE
Fix concurrency limiter inbounds

### DIFF
--- a/message_sender/views.py
+++ b/message_sender/views.py
@@ -106,22 +106,21 @@ class InboundViewSet(viewsets.ModelViewSet):
             if request.data["channel_data"].get("session_event", None) == \
                     "close":
                 close_event = True
-                reply_field = "reply_to"
-                from_field = "from"
+                related_outbound = request.data["reply_to"]
+                msisdn = request.data["from"]
         elif "session_event" in request.data:  # Handle message from Vumi
             if request.data["session_event"] == "close":
                 close_event = True
-                reply_field = "in_reply_to"
-                from_field = "from_addr"
+                related_outbound = request.data["in_reply_to"]
+                msisdn = request.data["from_addr"]
 
         if close_event:
             try:
                 message = Outbound.objects.get(
-                    vumi_message_id=request.data[reply_field])
+                    vumi_message_id=related_outbound)
             except ObjectDoesNotExist:
                 message = Outbound.objects.filter(
-                    to_addr=request.data[from_field]).order_by(
-                    '-created_at').last()
+                    to_addr=msisdn).order_by('-created_at').last()
             if message:
                 outbound_type = "voice" if "voice_speech_url" in \
                     message.metadata else "text"

--- a/message_sender/views.py
+++ b/message_sender/views.py
@@ -102,12 +102,12 @@ class InboundViewSet(viewsets.ModelViewSet):
             return super(InboundViewSet, self).create(request, *args, **kwargs)
 
         close_event = False
-        if "channel_data" in request.data:  # Handle message from Junebug
-            if request.data["channel_data"].get("session_event", None) == \
-                    "close":
-                close_event = True
-                related_outbound = request.data["reply_to"]
-                msisdn = request.data["from"]
+        # Handle message from Junebug
+        if request.data.get("channel_data", {}).get("session_event", None) == \
+                "close":
+            close_event = True
+            related_outbound = request.data["reply_to"]
+            msisdn = request.data["from"]
         elif "session_event" in request.data:  # Handle message from Vumi
             if request.data["session_event"] == "close":
                 close_event = True


### PR DESCRIPTION
When getting the data for the concurrency limiter from an inbound message, the `in_reply_to` field might be empty. This was causing a MultipleObjectsReturned exception since there can be multiple Outbounds with an empty `vumi_message_id`.
This checks that field isn't empty before trying to find a related Outbound message.