### PR TITLE
Fix message endpoint ordering

### DIFF
--- a/message_sender/tests.py
+++ b/message_sender/tests.py
@@ -372,6 +372,30 @@ class TestVumiMessagesAPI(AuthenticatedAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data["results"]), 2)
 
+    def test_created_at_ordering_filter_outbound(self):
+        """
+        We should be able to order the results of the Outbound list endpoint
+        by the created_at timestamp.
+        """
+        out1 = self.make_outbound()
+        out2 = self.make_outbound()
+
+        response = self.client.get('/api/v1/outbound/?{}'.format(urlencode({
+            'ordering': 'created_at'}))
+        )
+        self.assertEqual(
+            [o['id'] for o in response.data["results"]],
+            [out1, out2]
+        )
+
+        response = self.client.get('/api/v1/outbound/?{}'.format(urlencode({
+            'ordering': '-created_at'}))
+        )
+        self.assertEqual(
+            [o['id'] for o in response.data["results"]],
+            [out2, out1]
+        )
+
     def test_from_addr_filter_inbound(self):
         """
         When filtering on from_addr, only the inbounds with the specified from
@@ -404,6 +428,30 @@ class TestVumiMessagesAPI(AuthenticatedAPITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data["results"]), 2)
+
+    def test_created_at_ordering_filter_inbound(self):
+        """
+        We should be able to order the results of the Inbound list endpoint
+        by the created_at timestamp.
+        """
+        in1 = self.make_inbound('1234')
+        in2 = self.make_inbound('1234')
+
+        response = self.client.get('/api/v1/inbound/?{}'.format(urlencode({
+            'ordering': 'created_at'}))
+        )
+        self.assertEqual(
+            [i['id'] for i in response.data["results"]],
+            [in1, in2]
+        )
+
+        response = self.client.get('/api/v1/inbound/?{}'.format(urlencode({
+            'ordering': '-created_at'}))
+        )
+        self.assertEqual(
+            [i['id'] for i in response.data["results"]],
+            [in2, in1]
+        )
 
     def test_create_inbound_data_no_limit(self):
         existing_outbound = self.make_outbound()

--- a/message_sender/views.py
+++ b/message_sender/views.py
@@ -88,7 +88,6 @@ class OutboundFilter(filters.FilterSet):
                   'delivered', 'attempts', 'metadata',
                   'created_at', 'updated_at',
                   'before', 'after')
-        ordering_fields = ('created_at',)
 
 
 class OutboundViewSet(viewsets.ModelViewSet):
@@ -99,6 +98,8 @@ class OutboundViewSet(viewsets.ModelViewSet):
     queryset = Outbound.objects.all()
     serializer_class = OutboundSerializer
     filter_class = OutboundFilter
+    filter_backends = (filters.DjangoFilterBackend, filters.OrderingFilter)
+    ordering_fields = ('created_at',)
 
     @papertrail.debug('api_outbound_create', sample=0.1)
     def create(self, *args, **kwargs):
@@ -113,7 +114,6 @@ class InboundFilter(filters.FilterSet):
         fields = (
             'message_id', 'in_reply_to', 'to_addr', 'content',
             'transport_name', 'transport_type', 'created_at', 'updated_at',)
-        ordering_fields = ('created_at',)
 
 
 class InboundViewSet(viewsets.ModelViewSet):
@@ -124,6 +124,8 @@ class InboundViewSet(viewsets.ModelViewSet):
     permission_classes = (IsAuthenticated,)
     queryset = Inbound.objects.all()
     filter_class = InboundFilter
+    filter_backends = (filters.DjangoFilterBackend, filters.OrderingFilter)
+    ordering_fields = ('created_at',)
 
     def get_serializer_class(self):
         if self.action == 'create':


### PR DESCRIPTION
We want to be able to specify ordering on the inbound and outbound list endpoints according to the `created_at` field.

Currently, this is not properly specified, so we are unable to do so.

This PR seeks to fix that issue.