### PR TITLE
Use seed-services-client for API requests

### DIFF
--- a/message_sender/tests.py
+++ b/message_sender/tests.py
@@ -497,7 +497,7 @@ class TestVumiMessagesAPI(AuthenticatedAPITestCase):
         create_id_post = responses.calls[1]
 
         self.assertEqual(
-            json.loads(create_id_post.request.body.decode("utf-8")),
+            json.loads(create_id_post.request.body),
             {
                 "details": {
                     "default_addr_type": "msisdn",

--- a/seed_message_sender/utils.py
+++ b/seed_message_sender/utils.py
@@ -1,7 +1,13 @@
-import requests
 from django.conf import settings
 from importlib import import_module
-from requests.adapters import HTTPAdapter
+from seed_services_client import IdentityStoreApiClient
+
+identity_store_client = IdentityStoreApiClient(
+    settings.IDENTITY_STORE_TOKEN,
+    settings.IDENTITY_STORE_URL,
+    retries=5,
+    timeout=settings.DEFAULT_REQUEST_TIMEOUT,
+)
 
 
 def get_available_metrics():
@@ -20,50 +26,18 @@ def load_callable(dotted_path_to_callable):
 
 
 def get_identity_address(identity_uuid, use_communicate_through=False):
-    url = "%s/%s/%s/addresses/msisdn" % (settings.IDENTITY_STORE_URL,
-                                         "identities", identity_uuid)
     params = {"default": True}
     if use_communicate_through:
         params['use_communicate_through'] = True
-    headers = {
-        'Authorization': 'Token %s' % settings.IDENTITY_STORE_TOKEN,
-        'Content-Type': 'application/json'
-    }
-    session = requests.Session()
-    session.mount(settings.IDENTITY_STORE_URL, HTTPAdapter(max_retries=5))
-    result = session.get(
-        url,
-        params=params,
-        headers=headers,
-        timeout=settings.DEFAULT_REQUEST_TIMEOUT
-    )
-    result.raise_for_status()
-    r = result.json()
-    if len(r["results"]) > 0:
-        return r["results"][0]["address"]
-    else:
-        return None
+
+    return identity_store_client.get_identity_address(
+        identity_uuid, params=params)
 
 
 def get_identity_by_address(address_value, address_type="msisdn"):
-    url = "%s/identities/search/" % (settings.IDENTITY_STORE_URL)
+    r = identity_store_client.get_identity_by_address(address_type,
+                                                      address_value)
 
-    params = {"details__addresses__%s" % address_type: address_value}
-    headers = {
-        'Authorization': 'Token %s' % settings.IDENTITY_STORE_TOKEN,
-        'Content-Type': 'application/json'
-    }
-
-    session = requests.Session()
-    session.mount(settings.IDENTITY_STORE_URL, HTTPAdapter(max_retries=5))
-    result = session.get(
-        url,
-        params=params,
-        headers=headers,
-        timeout=settings.DEFAULT_REQUEST_TIMEOUT
-    )
-    result.raise_for_status()
-    r = result.json()
     if len(r["results"]) > 0:
         return r
     else:
@@ -71,20 +45,4 @@ def get_identity_by_address(address_value, address_type="msisdn"):
 
 
 def create_identity(identity):
-    url = "%s/identities/" % (settings.IDENTITY_STORE_URL)
-    headers = {
-        'Authorization': 'Token %s' % settings.IDENTITY_STORE_TOKEN,
-        'Content-Type': 'application/json'
-    }
-
-    session = requests.Session()
-    session.mount(settings.IDENTITY_STORE_URL, HTTPAdapter(max_retries=5))
-    result = session.post(
-        url,
-        json=identity,
-        headers=headers,
-        timeout=settings.DEFAULT_REQUEST_TIMEOUT
-    )
-    result.raise_for_status()
-    r = result.json()
-    return r
+    return identity_store_client.create_identity(identity)

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'drfdocs==0.0.11',
         'django-redis-cache==1.7.1',
         'seed-papertrail>=1.5.1',
-        'seed-services-client>=0.21.0',
+        'seed-services-client>=0.29.0',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Instead of hardcoding URLs in this repo, use the API client.

This depends on an as-yet unreleased version of the client. The tests should pass once https://github.com/praekeltfoundation/seed-services-client/pull/39 is merged and released.