### PR TITLE
Ensure that we hit the index on the Outbound table

### DIFF
--- a/message_sender/test_utils.py
+++ b/message_sender/test_utils.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import datetime
 from django.test import TestCase, override_settings
 
 from .utils import daterange, make_absolute_url
@@ -36,6 +36,6 @@ class DateRangeTests(TestCase):
         daterange should return the list of dates that falls within the range
         """
         self.assertEqual(
-            list(daterange(date(2017, 1, 1), date(2017, 1, 3))),
-            [date(2017, 1, 1), date(2017, 1, 2), date(2017, 1, 3)]
+            list(daterange(datetime(2017, 1, 1), datetime(2017, 1, 3))),
+            [datetime(2017, 1, 1), datetime(2017, 1, 2), datetime(2017, 1, 3)]
         )


### PR DESCRIPTION
By doing a `created_at__date=date` in the filter, it results in a WHERE clause like `WHERE ("message_sender_outbound"."created_at" AT TIME ZONE 'UTC')::date = '2016-09-01'::date`, which doesn't hit the index on `created_at`, causing a full table scan.

This PR changes our filters, so that we're doing a `__gte=date` and `__lt=date + 1 day` filter instead, since this results in a WHERE clause like `"message_sender_outbound"."created_at" >= '2016-09-01 00:00:00' AND "message_sender_outbound"."created_at" < '2016-09-02 00:00:00'`, which does hit the index on `created_at`.