### PR TITLE
Add sending images with the Whatsapp channel

### DIFF
--- a/message_sender/tasks.py
+++ b/message_sender/tasks.py
@@ -271,6 +271,16 @@ class SendMessage(Task):
                         speech_url=speech_url,
                         session_event="new")
                     l.info("Sent voice message to <%s>" % message.to_addr)
+
+                if "image_url" in message.metadata:
+                    # Image message
+                    image_url = message.metadata["image_url"]
+                    vumiresponse = sender.send_image(
+                        text_to_addr_formatter(message.to_addr),
+                        message.content,
+                        image_url=image_url)
+                    l.info("Sent image message to <%s>" % (message.to_addr,))
+
                 else:
                     # Plain content
                     vumiresponse = sender.send_text(


### PR DESCRIPTION
This will allow us to send images from seed to whatsapp subscribers, the text is sent as the `image_caption` so that we only send one message.