### PR TITLE
Handle Whatsapp API error response

### DIFF
--- a/message_sender/factory.py
+++ b/message_sender/factory.py
@@ -361,7 +361,7 @@ class WhatsAppApiSender(object):
             response.raise_for_status()
         except requests_exceptions.HTTPError as exc:
             resp = exc.response.text
-            if not("1006" in resp and "unknown contact" in resp):
+            if not ("1006" in resp and "unknown contact" in resp):
                 raise exc
         return response.json()
 


### PR DESCRIPTION
The API responses causes an exception to be raised when the contact is not found.

We now check for the specific error and handle it or raise it again.

I also noticed the `WhatsAppApiSender` was still using the `WASSUP_SESSIONS` variable.