### PR TITLE
Feature/momza 1044 add event for wa message expiry

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -3,8 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE",
-                          "seed_message_sender.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "seed_message_sender.settings")
 
     from django.core.management import execute_from_command_line
 

--- a/message_sender/factory.py
+++ b/message_sender/factory.py
@@ -287,11 +287,13 @@ WHATSAPP_SESSIONS = {}
 
 
 class WhatsAppApiSender(object):
-    def __init__(self, api_url, token, hsm_namespace, hsm_element_name, session=None):
+    def __init__(self, api_url, token, hsm_namespace, hsm_element_name, ttl,
+                 session=None):
         self.api_url = api_url
         self.token = token
         self.hsm_namespace = hsm_namespace
         self.hsm_element_name = hsm_element_name
+        self.ttl = ttl
         self.time_period = 0
         self.max_time_period = 30
 
@@ -341,7 +343,7 @@ class WhatsAppApiSender(object):
             urllib_parse.urljoin(self.api_url, "/v1/messages"),
             json={
                 "to": whatsapp_id,
-                "ttl": 604800,  # 7 days
+                "ttl": self.ttl,
                 "type": "hsm",
                 "hsm": {
                     "namespace": self.hsm_namespace,
@@ -367,18 +369,6 @@ class WhatsAppApiSender(object):
 
             if not ("1006" in resp and "unknown contact" in resp):
                 raise exc
-
-                if "410" in resp:
-                    if (
-                        self.time_period == 0
-                        and self.time_period < self.max_time_period
-                    ):
-                        self.time_period += 7
-                        raise exc  # or send message?
-                    elif self.time_period < self.max_time_period:
-                        self.time_period += 7
-                elif self.time_period >= self.max_time_period:
-                    self.time_period = 0
 
         return response.json()
 
@@ -479,5 +469,5 @@ class MessageClientFactory(object):
             channel.configuration["API_TOKEN"],
             channel.configuration.get("HSM_NAMESPACE"),
             channel.configuration.get("HSM_ELEMENT_NAME"),
-            channel.configuration.get("MESSAGE_TTL"),
+            channel.configuration.get("TTL"),
         )

--- a/message_sender/factory.py
+++ b/message_sender/factory.py
@@ -295,8 +295,6 @@ class WhatsAppApiSender(object):
         self.hsm_namespace = hsm_namespace
         self.hsm_element_name = hsm_element_name
         self.ttl = ttl
-        self.time_period = 0
-        self.max_time_period = 30
 
         distribution = pkg_resources.get_distribution("seed_message_sender")
 
@@ -340,18 +338,21 @@ class WhatsAppApiSender(object):
         return whatsapp_id
 
     def send_hsm(self, whatsapp_id, content):
+        data = {
+            "to": whatsapp_id,
+            "type": "hsm",
+            "hsm": {
+                "namespace": self.hsm_namespace,
+                "element_name": self.hsm_element_name,
+                "localizable_params": [{"default": content}],
+            }
+            }
+
+        if self.ttl is not None:
+            data["ttl"] = self.ttl
         response = self.session.post(
             urllib_parse.urljoin(self.api_url, "/v1/messages"),
-            json={
-                "to": whatsapp_id,
-                "ttl": self.ttl,
-                "type": "hsm",
-                "hsm": {
-                    "namespace": self.hsm_namespace,
-                    "element_name": self.hsm_element_name,
-                    "localizable_params": [{"default": content}],
-                },
-            },
+            json=data
         )
         return self.return_response(response)
 

--- a/message_sender/factory.py
+++ b/message_sender/factory.py
@@ -345,14 +345,13 @@ class WhatsAppApiSender(object):
                 "namespace": self.hsm_namespace,
                 "element_name": self.hsm_element_name,
                 "localizable_params": [{"default": content}],
-            }
-            }
+            },
+        }
 
         if self.ttl is not None:
             data["ttl"] = self.ttl
         response = self.session.post(
-            urllib_parse.urljoin(self.api_url, "/v1/messages"),
-            json=data
+            urllib_parse.urljoin(self.api_url, "/v1/messages"), json=data
         )
         return self.return_response(response)
 

--- a/message_sender/factory.py
+++ b/message_sender/factory.py
@@ -368,15 +368,17 @@ class WhatsAppApiSender(object):
             if not ("1006" in resp and "unknown contact" in resp):
                 raise exc
 
-                if ("410" in resp):
-                    if (self.time_period == 0
-                       and self.time_period < self.max_time_period):
+                if "410" in resp:
+                    if (
+                        self.time_period == 0
+                        and self.time_period < self.max_time_period
+                    ):
                         self.time_period += 7
                         raise exc  # or send message?
-                    elif (self.time_period < self.max_time_period):
+                    elif self.time_period < self.max_time_period:
                         self.time_period += 7
-                elif (self.time_period >= self.max_time_period):
-                        self.time_period = 0
+                elif self.time_period >= self.max_time_period:
+                    self.time_period = 0
 
         return response.json()
 

--- a/message_sender/factory.py
+++ b/message_sender/factory.py
@@ -287,8 +287,9 @@ WHATSAPP_SESSIONS = {}
 
 
 class WhatsAppApiSender(object):
-    def __init__(self, api_url, token, hsm_namespace, hsm_element_name, ttl,
-                 session=None):
+    def __init__(
+        self, api_url, token, hsm_namespace, hsm_element_name, ttl, session=None
+    ):
         self.api_url = api_url
         self.token = token
         self.hsm_namespace = hsm_namespace

--- a/message_sender/tests.py
+++ b/message_sender/tests.py
@@ -3993,7 +3993,7 @@ class TestWhatsAppAPISender(TestCase):
         send_text should delegate to send_text_message when there is no HSM
         setup.
         """
-        sender = WhatsAppApiSender("http://whatsapp", "test-token", None, None)
+        sender = WhatsAppApiSender("http://whatsapp", "test-token", None, None, None)
         sender.send_text_message = MagicMock(
             return_value={"messages": [{"id": "message-id"}]}
         )
@@ -4007,7 +4007,7 @@ class TestWhatsAppAPISender(TestCase):
         send_text should delegate to send_hsm when there are HSM config values.
         """
         sender = WhatsAppApiSender(
-            "http://whatsapp", "test-token", "hsm-namespace", "hsm-element-name"
+            "http://whatsapp", "test-token", "hsm-namespace", "hsm-element-name", "ttl"
         )
         sender.send_hsm = MagicMock(return_value={"messages": [{"id": "message-id"}]})
 
@@ -4020,7 +4020,7 @@ class TestWhatsAppAPISender(TestCase):
         If the sending fails with a unknown contact error, contact_check should
         be called then the send should be retried.
         """
-        sender = WhatsAppApiSender("http://whatsapp", "test-token", None, None)
+        sender = WhatsAppApiSender("http://whatsapp", "test-token", None, None, None)
         sender.get_contact = MagicMock(return_value="27820001001")
         sender.send_text_message = MagicMock(
             return_value={
@@ -4046,7 +4046,7 @@ class TestWhatsAppAPISender(TestCase):
         """
         send_image should raise an API sender exception as it is not supported
         """
-        sender = WhatsAppApiSender("http://whatsapp", "test-token", None, None)
+        sender = WhatsAppApiSender("http://whatsapp", "test-token", None, None, None)
         self.assertRaises(
             WhatsAppApiSenderException,
             sender.send_image,
@@ -4059,7 +4059,7 @@ class TestWhatsAppAPISender(TestCase):
         """
         send_voice should raise an API sender exception as it is not supported
         """
-        sender = WhatsAppApiSender("http://whatsapp", "test-token", None, None)
+        sender = WhatsAppApiSender("http://whatsapp", "test-token", None, None, None)
         self.assertRaises(
             WhatsAppApiSenderException,
             sender.send_voice,
@@ -4072,7 +4072,7 @@ class TestWhatsAppAPISender(TestCase):
         """
         fire_metric should raise an API sender exception as it is not supported
         """
-        sender = WhatsAppApiSender("http://whatsapp", "test-token", None, None)
+        sender = WhatsAppApiSender("http://whatsapp", "test-token", None, None, None)
         self.assertRaises(
             WhatsAppApiSenderException, sender.fire_metric, "test.metric", 7
         )
@@ -4083,7 +4083,7 @@ class TestWhatsAppAPISender(TestCase):
         get_contact should make the appropriate request to the WhatsApp API, and return
         the contact ID.
         """
-        sender = WhatsAppApiSender("http://whatsapp", "test-token", None, None)
+        sender = WhatsAppApiSender("http://whatsapp", "test-token", None, None, None)
 
         responses.add(
             method=responses.POST,
@@ -4109,7 +4109,7 @@ class TestWhatsAppAPISender(TestCase):
         get_contact should make the appropriate request to the WhatsApp API, and trigger
         a webhook if the contact doesn't exist
         """
-        sender = WhatsAppApiSender("http://whatsapp", "test-token", None, None)
+        sender = WhatsAppApiSender("http://whatsapp", "test-token", None, None, None)
 
         responses.add(
             method=responses.POST,
@@ -4145,7 +4145,7 @@ class TestWhatsAppAPISender(TestCase):
         send_hsm should make the appropriate request to the WhatsApp API
         """
         sender = WhatsAppApiSender(
-            "http://whatsapp", "test-token", "hsm-namespace", "hsm-element-name"
+            "http://whatsapp", "test-token", "hsm-namespace", "hsm-element-name", "ttl"
         )
 
         responses.add(
@@ -4161,7 +4161,7 @@ class TestWhatsAppAPISender(TestCase):
             json.loads(request.body),
             {
                 "to": "27820001001",
-                "ttl": 604800,
+                "ttl": "ttl",
                 "type": "hsm",
                 "hsm": {
                     "namespace": "hsm-namespace",
@@ -4178,7 +4178,7 @@ class TestWhatsAppAPISender(TestCase):
         contact error returned by the API.
         """
         sender = WhatsAppApiSender(
-            "http://whatsapp", "test-token", "hsm-namespace", "hsm-element-name"
+            "http://whatsapp", "test-token", "hsm-namespace", "hsm-element-name", "ttl"
         )
 
         responses.add(
@@ -4208,7 +4208,7 @@ class TestWhatsAppAPISender(TestCase):
         send_hsm should re-raise the HTTPError if it is not handled
         """
         sender = WhatsAppApiSender(
-            "http://whatsapp", "test-token", "hsm-namespace", "hsm-element-name"
+            "http://whatsapp", "test-token", "hsm-namespace", "hsm-element-name", "ttl"
         )
 
         responses.add(
@@ -4239,7 +4239,7 @@ class TestWhatsAppAPISender(TestCase):
         """
         send_text_message should make the appropriate request to the WhatsApp API
         """
-        sender = WhatsAppApiSender("http://whatsapp", "test-token", None, None)
+        sender = WhatsAppApiSender("http://whatsapp", "test-token", None, None, None)
 
         responses.add(
             method=responses.POST,

--- a/message_sender/tests.py
+++ b/message_sender/tests.py
@@ -4161,6 +4161,7 @@ class TestWhatsAppAPISender(TestCase):
             json.loads(request.body),
             {
                 "to": "27820001001",
+                "ttl": 604800,
                 "type": "hsm",
                 "hsm": {
                     "namespace": "hsm-namespace",

--- a/message_sender/tests.py
+++ b/message_sender/tests.py
@@ -4145,7 +4145,7 @@ class TestWhatsAppAPISender(TestCase):
         send_hsm should make the appropriate request to the WhatsApp API
         """
         sender = WhatsAppApiSender(
-            "http://whatsapp", "test-token", "hsm-namespace", "hsm-element-name", "ttl"
+            "http://whatsapp", "test-token", "hsm-namespace", "hsm-element-name", 604800
         )
 
         responses.add(
@@ -4161,7 +4161,7 @@ class TestWhatsAppAPISender(TestCase):
             json.loads(request.body),
             {
                 "to": "27820001001",
-                "ttl": "ttl",
+                "ttl": 604800,
                 "type": "hsm",
                 "hsm": {
                     "namespace": "hsm-namespace",


### PR DESCRIPTION
Added a TTL on templated messages 

The solution that was decided on this:

If a WhatsApp isn't delivered for x time period, we send them an SMS telling them that
We only send an SMS once every y time period
eg. If x is 7 days and y is a month, and there's a message that hasn't been delivered in 7 days, we tell them that. Any other failed messages within a month from that time, we do nothing with. If after a month, there's another message that hasn't been delivered in 7 days, we then send them the SMS again.