### PR TITLE
removed where to_addr is set to none

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 htmlcov/
+.vscode/
 .tox/
 .coverage
 .coverage.*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "${workspaceFolder}/ve/bin/python"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "${workspaceFolder}/ve/bin/python"
-}

--- a/message_sender/tasks.py
+++ b/message_sender/tasks.py
@@ -317,7 +317,7 @@ class SendMessage(Task):
                             text_to_addr_formatter(message.to_addr),
                             message.content,
                             session_event="new",
-                            )
+                        )
                         log.info("Sent text message to <%s>" % (message.to_addr,))
                     else:
                         self.fire_failed_msisdn_lookup(message.to_addr)

--- a/message_sender/tasks.py
+++ b/message_sender/tasks.py
@@ -263,6 +263,8 @@ class SendMessage(Task):
                     message.to_addr = get_identity_address(
                         message.to_identity, use_communicate_through=True
                     )
+                    if message.to_addr is None:
+                        self.fire_failed_msisdn_lookup(message.to_addr)
 
                 if message.to_addr and not message.to_identity:
                     result = get_identity_by_address(message.to_addr)
@@ -312,15 +314,12 @@ class SendMessage(Task):
 
                 else:
                     # Plain content
-                    if message.to_addr is not None:
-                        vumiresponse = sender.send_text(
-                            text_to_addr_formatter(message.to_addr),
-                            message.content,
-                            session_event="new",
-                        )
-                        log.info("Sent text message to <%s>" % (message.to_addr,))
-                    else:
-                        self.fire_failed_msisdn_lookup(message.to_addr)
+                    vumiresponse = sender.send_text(
+                        text_to_addr_formatter(message.to_addr),
+                        message.content,
+                        session_event="new",
+                    )
+                    log.info("Sent text message to <%s>" % (message.to_addr,))
 
                 message.last_sent_time = timezone.now()
                 message.attempts += 1

--- a/message_sender/tasks.py
+++ b/message_sender/tasks.py
@@ -353,8 +353,6 @@ class SendMessage(Task):
         else:
             # This is for retries based on async nacks from the transport.
             log.info("Message <%s> at max retries." % str(message_id))
-            message.to_addr = ""
-            message.save(update_fields=["to_addr"])
             fire_metric.apply_async(
                 kwargs={
                     "metric_name": "vumimessage.maxretries.sum",

--- a/message_sender/tests.py
+++ b/message_sender/tests.py
@@ -3201,8 +3201,7 @@ class TestFailedMsisdnLookUp(TestCase):
 
         webhook = responses.calls[0].request
         self.assertEqual(
-            json.loads(webhook.body),
-            {"hook": hook.dict(), "data": {"to_addr": None}}
+            json.loads(webhook.body), {"hook": hook.dict(), "data": {"to_addr": None}}
         )
 
 

--- a/message_sender/tests.py
+++ b/message_sender/tests.py
@@ -3180,7 +3180,8 @@ class TestFailedMsisdnLookUp(TestCase):
         response = {"next": None, "previous": None, "results": []}
         responses.add(
             responses.GET,
-            "%s/identities/%s/addresses/msisdn" % (settings.IDENTITY_STORE_URL, identity),  # noqa
+            "%s/identities/%s/addresses/msisdn"
+            % (settings.IDENTITY_STORE_URL, identity),  # noqa
             json=response,
             status=200,
         )
@@ -3242,8 +3243,8 @@ class TestFailedMsisdnLookUp(TestCase):
 
         webhook = responses.calls[-1].request
         self.assertEqual(
-            json.loads(webhook.body), {"hook": hook.dict(),
-                                       "data": {"to_identity": "0c03d360"}}
+            json.loads(webhook.body),
+            {"hook": hook.dict(), "data": {"to_identity": "0c03d360"}},
         )
 
 

--- a/message_sender/tests.py
+++ b/message_sender/tests.py
@@ -3186,11 +3186,6 @@ class TestFailedMsisdnLookUp(TestCase):
             status=200,
         )
 
-    def add_metrics_response(self):
-        responses.add(
-            responses.POST, "http://metrics-url/metrics/", json={}, status=201
-        )
-
     @responses.activate
     def test_fire_failed_msisdn_lookup(self):
         """
@@ -3215,8 +3210,6 @@ class TestFailedMsisdnLookUp(TestCase):
         Channel.objects.create(**new_channel)
         self.assertEqual(Channel.objects.filter(default=True).count(), 1)
         channel = Channel.objects.get(channel_id="NEW_DEFAULT")
-
-        self.add_metrics_response()
 
         self.add_identity_no_address_search_response("", "0c03d360")
 


### PR DESCRIPTION
Currently, if there is no to_addr, we get an error later on when we try to send the message. 

In this PR, we  ensure that to_addr is not None earlier on, before we try to send that message, and handle the issue there