### PR TITLE
Upgrade security dependancies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        "Django==2.1.2",
+        "Django==2.2.3",
         "djangorestframework==3.9.1",
         "dj-database-url==0.5.0",
         "psycopg2==2.7.5",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "Django==2.1.2",
-        "djangorestframework==3.8.2",
+        "djangorestframework==3.9.1",
         "dj-database-url==0.5.0",
         "psycopg2==2.7.5",
         "raven==6.9.0",


### PR DESCRIPTION
Some dependancies have security vulneribilities that we need to patch. This PR upgrade djangorestframework and Django.

It also upgrade Django to 2.2.3, which is the latest LTS release